### PR TITLE
Changed dependency for xercesImpl

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -161,7 +161,7 @@
   <classpathentry kind="var" path="M2_REPO/org/jvnet/winp/winp/1.14/winp-1.14.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/codehaus/woodstox/wstx-asl/3.2.7/wstx-asl-3.2.7.jar"/>
   <classpathentry kind="var" path="M2_REPO/xalan/xalan/2.7.1/xalan-2.7.1.jar"/>
-  <classpathentry kind="var" path="M2_REPO/xerces/xercesImpl/2.9.1/xercesImpl-2.9.1.jar"/>
+  <classpathentry kind="var" path="M2_REPO/xerces/xercesImpl/2.9.1/xercesImpl-2.12.0.jar"/>
   <classpathentry kind="var" path="M2_REPO/xml-apis/xml-apis/1.3.04/xml-apis-1.3.04.jar"/>
   <classpathentry kind="var" path="M2_REPO/de/zeigermann/xml/xml-im-exporter/1.1/xml-im-exporter-1.1.jar"/>
   <classpathentry kind="var" path="M2_REPO/xpp3/xpp3/1.1.4c/xpp3-1.1.4c.jar"/>


### PR DESCRIPTION
Changing the dependency for xercesImpl from 2.9.1 to 2.12.0.
The release of 2.9.1 is from Oct. 2008, and we are facing some problems with jenkins job dsl API I think it's related to this outdated version.

https://issues.jenkins-ci.org/browse/JENKINS-27548